### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/janlu3089/02e98b52-1b96-46bd-a400-18692c241fe3/6342814f-cebd-4566-9baa-7fea44e6f66d/_apis/work/boardbadge/58f5a595-31ea-454b-8fff-86b34bcd224d)](https://dev.azure.com/janlu3089/02e98b52-1b96-46bd-a400-18692c241fe3/_boards/board/t/6342814f-cebd-4566-9baa-7fea44e6f66d/Microsoft.RequirementCategory)
 # MyWebsite


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.